### PR TITLE
Support different app name for newrelic

### DIFF
--- a/newrelic_beego.go
+++ b/newrelic_beego.go
@@ -26,7 +26,10 @@ func EndTransaction(ctx *context.Context) {
 }
 
 func init() {
-	appName := beego.AppConfig.String("appname")
+	appName := beego.AppConfig.String("newrelic_appname")
+	if appName == "" {
+		appName = beego.AppConfig.String("appname")
+	}
 	license := beego.AppConfig.String("newrelic_license")
 	if license == "" {
 		beego.Warn("Please set NewRelic license in config(newrelic_license)")


### PR DESCRIPTION
For us appname != name-in-newrelic. I guess it's quite common case.
